### PR TITLE
Add ability to perform aggregate queries on Collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-firebase-state",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Simplify Firebase integration in Svelte and SvelteKit with reactive state management for Firestore and Realtime Database.",
   "keywords": [
     "svelte",

--- a/src/routes/(docs)/firestore/collection-state/+page.svelte
+++ b/src/routes/(docs)/firestore/collection-state/+page.svelte
@@ -5,6 +5,8 @@
   import CollectionStateDemo1Code from "./CollectionStateDemo1.svelte?raw";
   import CollectionStateDemo2 from "./CollectionStateDemo2.svelte";
   import CollectionStateDemo2Code from "./CollectionStateDemo2.svelte?raw";
+  import CollectionStateDemo3 from "./CollectionStateDemo3.svelte";
+  import CollectionStateDemo3Code from "./CollectionStateDemo3.svelte?raw";
 </script>
 
 <div class="title">
@@ -66,6 +68,36 @@ const tasks = new CollectionState<DbTasks, AppTasks>({
   type="(currentUser: User | null) => QueryConstraint[];"
   description="The query constraints"
   isOptional
+/>
+
+<Param
+  name="aggregate"
+  type={"Record<string, AggregateFieldType>"}
+  description="An object defining aggregate queries to be performed on the collection. Each key represents a field name for the result of the aggregation, and the value specifies the aggregation function and (for some functions) the field to aggregate on. The aggregation results are updated when the collection changes if 'listen' is set to true.",
+  isOptional
+  code={`// aggregate example
+
+import { count, average, sum } from "firebase/firestore";
+
+const users = new CollectionState<DbTasks, AppTasks>({
+  firestore,
+  path: "your/firestore/collection/path",
+  aggregate: {
+    count: count(),
+    averageAge: average("age"),
+    totalAge: sum("age"),
+  },
+});
+
+$inspect(users.data);
+/*
+{
+  count: 2,
+  averageAge: 30,
+  totalAge: 60,
+}
+*/
+`}
 />
 
 <Param
@@ -164,6 +196,10 @@ const users = new CollectionState<DbUser, AppUser>({
 
 <Example text="Example: Listen to a collection" code={CollectionStateDemo2Code}>
   <CollectionStateDemo2 />
+</Example>
+
+<Example text="Example: Summarize collection data with aggregation queries" code={CollectionStateDemo3Code}>
+  <CollectionStateDemo3 />
 </Example>
 
 <style>

--- a/src/routes/(docs)/firestore/collection-state/CollectionStateDemo3.svelte
+++ b/src/routes/(docs)/firestore/collection-state/CollectionStateDemo3.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import { CollectionState } from "$lib/firestore/CollectionState.svelte.js";
+    import { firestore } from "@/www-lib/firebase.js";
+    import { average, count, sum } from "firebase/firestore";
+
+    interface User {
+      name: string;
+    }
+
+    const users = new CollectionState<any>({
+      firestore,
+      listen: true,
+      path: "users_2",
+      aggregate: {
+        count: count(),
+        averageAge: average("age"),
+        totalAge: sum("age")
+      }
+    });
+  </script>
+
+  {JSON.stringify(users.data)}


### PR DESCRIPTION
Two issues:
1. The assignment to `this.value` has type errors. The types are a bit convoluted, so I'm not exactly sure what should change there.
2. Issues running `dev`:

```
> svelte-firebase-state@1.0.3 dev
> vite dev

Port 5173 is in use, trying another one...

  VITE v5.4.11  ready in 382 ms

  ➜  Local:   http://localhost:5174/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
Error:   Failed to scan for dependencies from entries:
  /Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/+layout.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/+layout.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/+page.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/image/+page.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/firestore/+layout.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/realtime/+layout.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/debug/firestore/+page.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/debug/realtime/+page.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/firestore/collection-state/+page.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/firestore/document-state/+page.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/realtime/node-list-state/+page.svelte
/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/(docs)/realtime/node-state/+page.svelte

  ✘ [ERROR] Syntax error "`"

    script:/Users/trentrand/Developer/personal/svelte-firebase-state/src/routes/image/+page.svelte?id=1:8:19:
      8 │   path: (user) => \`/users/\${user?.uid}/tasks\`,
        ╵                    ^
```

This error throws on `npm run dev`, fixed by removing escape characters throughout that line, but then `npm run build` fails.